### PR TITLE
LRScheduler parameter removed for Pytorch 2.6

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -82,7 +82,7 @@ class nnUNetPredictor(object):
         for i, f in enumerate(use_folds):
             f = int(f) if f != 'all' else f
             checkpoint = torch.load(join(model_training_output_dir, f'fold_{f}', checkpoint_name),
-                                    map_location=torch.device('cpu'))
+                                    map_location=torch.device('cpu'),weights_only=False)
             if i == 0:
                 trainer_name = checkpoint['trainer_name']
                 configuration_name = checkpoint['init_args']['configuration']

--- a/nnunetv2/training/lr_scheduler/polylr.py
+++ b/nnunetv2/training/lr_scheduler/polylr.py
@@ -8,7 +8,7 @@ class PolyLRScheduler(_LRScheduler):
         self.max_steps = max_steps
         self.exponent = exponent
         self.ctr = 0
-        super().__init__(optimizer, current_step if current_step is not None else -1, False)
+        super().__init__(optimizer, current_step if current_step is not None else -1)
 
     def step(self, current_step=None):
         if current_step is None or current_step == -1:


### PR DESCRIPTION
pip installs latest package of the torch, which does not support the current call of LRScheduler. Removed a parameter to align with the torch 2.6 api. 